### PR TITLE
Withdrawals Migration: Error Fixed

### DIFF
--- a/database/migrations/2023_09_20_130009_create_withdrawals_table.php
+++ b/database/migrations/2023_09_20_130009_create_withdrawals_table.php
@@ -16,9 +16,7 @@ return new class extends Migration
             $table->unsignedBigInteger('user_id');
             $table->enum('status', ['redeemed', 'not_redeemed'])->default('not_redeemed');
             $table->decimal('amount', 10, 2);
-            $table->timestamp('created_at')->default(now());
-            $table->timestamp('updated_at')->default(now())->onUpdate(now());
-            $table->boolean('is_deleted')->default(false);
+            $table->timestamps();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }


### PR DESCRIPTION
Withdrawal migration updated to use default timestamps to fix sql syntax error from migration.
Also, is_deleted column removed.