### PR TITLE
Updated swagger docs, fixed password change issue

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -24,9 +24,6 @@ class ResetPasswordController extends Controller
      *     path="/api/v1/auth/user/forgot-password",
      *     summary="Reset user password",
      *     tags={"Authentication"},
-     *     security={
-     *         {"bearerAuth": {}}
-     *     },
      *     @OA\RequestBody(
      *         @OA\MediaType(
      *             mediaType="application/json",
@@ -35,11 +32,7 @@ class ResetPasswordController extends Controller
      *                     property="email",
      *                     type="string"
      *                 ),
-     *                 @OA\Property(
-     *                     property="note",
-     *                     type="string"
-     *                 ),
-     *                 example={"email":"user@example.com", "note":"Thank you for the good work"}
+     *                 example={"email":"user@example.com"}
      *             )
      *         )
      *     ),
@@ -54,7 +47,7 @@ class ResetPasswordController extends Controller
      *         response=422,
      *         description="UNPROCESSABLE_ENTITY",
      *         @OA\JsonContent(
-     *             @OA\Examples(example="result", value={"message":{"[Field] is required", "[Field] is required"}, "statusCode":422}, summary="Reset user password"),
+     *             @OA\Examples(example="result", value={"message":"[email] is required", "statusCode":422}, summary="Reset user password"),
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -60,7 +60,7 @@ class ProfileController extends Controller
         /**
      * @OA\Post(
      *     path="/api/v1/auth/user/change-password",
-     *     tags={"Authentication"},
+     *     tags={"Profile"},
      *     summary="Change Password",
      *     security={
      *         {"bearerAuth": {}}
@@ -74,14 +74,14 @@ class ProfileController extends Controller
      *                     type="string"
      *                 ),
      *                 @OA\Property(
-     *                     property="new_password",
+     *                     property="password",
      *                     type="string"
      *                 ),
      *                 @OA\Property(
-     *                     property="confirm_password",
+     *                     property="password_confirmation",
      *                     type="string"
      *                 ),
-     *                 example={"current_password":"1Password", "new_password":"password123", "confirm_password":"password123"}
+     *                 example={"current_password":"1Password", "password":"password123", "password_confirmation":"password123"}
      *             )
      *         )
      *     ),


### PR DESCRIPTION
Someone updated the request input field names, which made Swagger to return 'field-required' error. So I have also updated the Swagger docs field names from `new_password` to `password` and from `confirm_password` to `password_confirmation`
![sw](https://github.com/hngx-org/Titans-food-backend/assets/85977511/1d9bf1c1-1ca4-42a0-8883-212511437591)
.